### PR TITLE
Fixed Picom DBus X Display Naming Discrepancy

### DIFF
--- a/app/src/main.rs
+++ b/app/src/main.rs
@@ -276,7 +276,7 @@ impl App {
             input_synth,
             screen: screen as u32,
             x11,
-            display: std::env::var("DISPLAY").unwrap().replace(':', "_"),
+            display: std::env::var("DISPLAY").unwrap().replace(':', "_").replace('.', "_"),
             cursors: Default::default(),
             atoms,
             pending_windows: Default::default(),


### PR DESCRIPTION
solves issue #5 

Picom in the latest builds seems to be naming its X Display
`_0_0` due to dbus service naming conventions

Original code searched for _0.0 which is invalid for dbus conventions
Added a replace() to replace the period with another underscore (`_`)